### PR TITLE
Defer more imports for even faster CLI

### DIFF
--- a/cibuildwheel/__main__.py
+++ b/cibuildwheel/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "argparse",
     "cibuildwheel.architecture",
@@ -12,7 +14,6 @@ __lazy_modules__ = [
     "cibuildwheel.util.helpers",
     "cibuildwheel.util.resources",
     "collections",
-    "collections.abc",
     "contextlib",
     "functools",
     "os",
@@ -37,10 +38,8 @@ import tarfile
 import textwrap
 import traceback
 import typing
-from collections.abc import Generator, Iterable, Sequence
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Any, Literal, TextIO
 
 import cibuildwheel
 import cibuildwheel.util
@@ -55,6 +54,11 @@ from cibuildwheel.typing import PLATFORMS, PlatformName
 from cibuildwheel.util.file import CIBW_CACHE_PATH, ensure_cache_sentinel
 from cibuildwheel.util.helpers import strtobool
 from cibuildwheel.util.resources import read_all_configs
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
+    from typing import Any, Literal, TextIO
 
 
 @dataclasses.dataclass

--- a/cibuildwheel/architecture.py
+++ b/cibuildwheel/architecture.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
-    "cibuildwheel.typing",
     "collections",
-    "collections.abc",
     "platform",
     "re",
     "shutil",
@@ -15,12 +15,17 @@ import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Set
 from enum import StrEnum, auto
-from typing import Final, Literal
+from typing import Final
 
 from cibuildwheel import errors
-from cibuildwheel.typing import PlatformName
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+    from typing import Literal
+
+    from cibuildwheel.typing import PlatformName
 
 PRETTY_NAMES: Final[dict[PlatformName, str]] = {
     "linux": "Linux",
@@ -94,7 +99,7 @@ class Architecture(StrEnum):
     x86_64_iphonesimulator = auto()
 
     @staticmethod
-    def parse_config(config: str, platform: PlatformName) -> "set[Architecture]":
+    def parse_config(config: str, platform: PlatformName) -> set[Architecture]:
         result = set()
         for arch_str in re.split(r"[\s,]+", config):
             match arch_str:
@@ -118,7 +123,7 @@ class Architecture(StrEnum):
         return result
 
     @staticmethod
-    def native_arch(platform: PlatformName) -> "Architecture | None":
+    def native_arch(platform: PlatformName) -> Architecture | None:
         native_machine = platform_module.machine()
         native_architecture = Architecture(native_machine)
 
@@ -155,7 +160,7 @@ class Architecture(StrEnum):
         return native_architecture
 
     @staticmethod
-    def auto_archs(platform: PlatformName) -> "set[Architecture]":
+    def auto_archs(platform: PlatformName) -> set[Architecture]:
         native_arch = Architecture.native_arch(platform)
         if native_arch is None:
             return set()  # can't build anything on this platform
@@ -171,7 +176,7 @@ class Architecture(StrEnum):
         return result
 
     @staticmethod
-    def all_archs(platform: PlatformName) -> "set[Architecture]":
+    def all_archs(platform: PlatformName) -> set[Architecture]:
         all_archs_map = {
             "linux": {
                 Architecture.x86_64,
@@ -195,7 +200,7 @@ class Architecture(StrEnum):
         return all_archs_map[platform]
 
     @staticmethod
-    def bitness_archs(platform: PlatformName, bitness: Literal["64", "32"]) -> "set[Architecture]":
+    def bitness_archs(platform: PlatformName, bitness: Literal["64", "32"]) -> set[Architecture]:
         # This map maps 64-bit architectures to their 32-bit equivalents.
         archs_map = {
             Architecture.x86_64: Architecture.i686,

--- a/cibuildwheel/environment.py
+++ b/cibuildwheel/environment.py
@@ -1,13 +1,19 @@
-__lazy_modules__ = ["bashlex", "bashlex.errors", "collections", "collections.abc"]
+from __future__ import annotations
+
+__lazy_modules__ = ["bashlex", "bashlex.errors", "collections"]
 
 import dataclasses
-from collections.abc import Mapping, Sequence
-from typing import Any, Protocol
+from typing import Protocol
 
 import bashlex
 import bashlex.errors
 
 from cibuildwheel import bashlex_eval
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
 
 
 class EnvironmentParseError(Exception):

--- a/cibuildwheel/extra.py
+++ b/cibuildwheel/extra.py
@@ -2,9 +2,10 @@
 These are utilities for the `/bin` scripts, not for the `cibuildwheel` program.
 """
 
+from __future__ import annotations
+
 __lazy_modules__ = [
     "collections",
-    "collections.abc",
     "io",
     "json",
     "time",
@@ -18,13 +19,17 @@ import time
 import typing
 import urllib.error
 import urllib.request
-from collections.abc import Mapping, Sequence
 from io import StringIO
-from typing import Any, NotRequired, Protocol
+from typing import NotRequired, Protocol
 
 from cibuildwheel import __version__ as cibw_version
 
 __all__ = ("Printable", "dump_python_configurations")
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any
 
 
 class Printable(Protocol):

--- a/cibuildwheel/frontend.py
+++ b/cibuildwheel/frontend.py
@@ -1,19 +1,23 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.logger",
     "cibuildwheel.util.helpers",
     "collections",
-    "collections.abc",
     "shlex",
 ]
 
 import dataclasses
 import shlex
 import typing
-from collections.abc import Sequence
 from typing import Literal, Self, get_args
 
 from cibuildwheel.logger import log
 from cibuildwheel.util.helpers import parse_key_value_string
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 BuildFrontendName = Literal["pip", "build", "build[uv]", "uv"]
 

--- a/cibuildwheel/logger.py
+++ b/cibuildwheel/logger.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.ci",
     "codecs",
     "collections",
-    "collections.abc",
     "contextlib",
     "functools",
     "hashlib",
@@ -27,15 +28,18 @@ import re
 import sys
 import textwrap
 import time
-from collections.abc import Generator
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, AnyStr, Final, Literal
+from typing import Final
 
 import humanize
 
 from cibuildwheel.ci import CIProvider, detect_ci_provider, filter_ansi_codes
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Generator
+    from typing import IO, AnyStr, Literal
+
     from cibuildwheel.options import Options
 
 FoldPattern = tuple[str, str]
@@ -252,7 +256,7 @@ class Logger:
             print(f"cibuildwheel: {c.bright_red}error{c.end}: {error}\n", file=sys.stderr)
 
     @contextlib.contextmanager
-    def print_summary(self, *, options: "Options") -> Generator[None, None, None]:
+    def print_summary(self, *, options: Options) -> Generator[None, None, None]:
         start = time.time()
         yield
         duration = time.time() - start
@@ -310,7 +314,7 @@ class Logger:
         # lowercase, shorten
         return identifier.lower()[:20]
 
-    def _github_step_summary(self, duration: float, options: "Options") -> str:
+    def _github_step_summary(self, duration: float, options: Options) -> str:
         """
         Returns the GitHub step summary, in markdown format.
         """

--- a/cibuildwheel/oci_container.py
+++ b/cibuildwheel/oci_container.py
@@ -1,12 +1,12 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.ci",
     "cibuildwheel.errors",
     "cibuildwheel.logger",
-    "cibuildwheel.typing",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.helpers",
     "collections",
-    "collections.abc",
     "io",
     "json",
     "os",
@@ -17,7 +17,6 @@ __lazy_modules__ = [
     "subprocess",
     "sys",
     "textwrap",
-    "types",
     "uuid",
 ]
 
@@ -33,18 +32,23 @@ import sys
 import textwrap
 import typing
 import uuid
-from collections.abc import Mapping, Sequence
 from enum import Enum
 from pathlib import Path, PurePath, PurePosixPath
-from types import TracebackType
-from typing import IO, Literal, Self, assert_never
+from typing import Literal, assert_never
 
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.errors import OCIEngineTooOldError
 from cibuildwheel.logger import log
-from cibuildwheel.typing import PathOrStr
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.helpers import FlexibleVersion, parse_key_value_string, strtobool
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from types import TracebackType
+    from typing import IO, Self
+
+    from cibuildwheel.typing import PathOrStr
 
 ContainerEngineName = Literal["docker", "podman"]
 
@@ -60,7 +64,7 @@ class OCIPlatform(Enum):
     S390X = "linux/s390x"
 
     @classmethod
-    def native(cls) -> "OCIPlatform":
+    def native(cls) -> OCIPlatform:
         """Return the current OCI platform, or raise ValueError if unknown."""
         arch = platform.machine().lower()
         mapping = {

--- a/cibuildwheel/options.py
+++ b/cibuildwheel/options.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.architecture",
     "cibuildwheel.environment",
@@ -35,7 +37,7 @@ import textwrap
 import tomllib
 from collections.abc import Callable, Generator, Iterable, Mapping, Sequence, Set
 from pathlib import Path
-from typing import Any, Final, Literal, Self, assert_never
+from typing import Final, assert_never
 
 from packaging.specifiers import SpecifierSet
 
@@ -51,6 +53,10 @@ from cibuildwheel.typing import PLATFORMS, PlatformName
 from cibuildwheel.util import resources
 from cibuildwheel.util.helpers import format_safe, parse_key_value_string, strtobool, unwrap
 from cibuildwheel.util.packaging import DependencyConstraints
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any, Literal, Self
 
 MANYLINUX_ARCHS: Final[tuple[str, ...]] = (
     "x86_64",

--- a/cibuildwheel/platforms/__init__.py
+++ b/cibuildwheel/platforms/__init__.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 __lazy_modules__ = ["sys"]
 
 import sys
-from typing import TYPE_CHECKING, Final, Protocol
+from typing import Final, Protocol
 
 from cibuildwheel import errors
 from cibuildwheel.platforms import android, ios, linux, macos, pyodide, windows
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from pathlib import Path

--- a/cibuildwheel/platforms/android.py
+++ b/cibuildwheel/platforms/android.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "build",
     "build.env",
     "cibuildwheel.architecture",
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
-    "cibuildwheel.options",
-    "cibuildwheel.selector",
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.file",
@@ -14,7 +14,6 @@ __lazy_modules__ = [
     "cibuildwheel.util.python_build_standalone",
     "cibuildwheel.venv",
     "collections",
-    "collections.abc",
     "csv",
     "elftools",
     "elftools.common.exceptions",
@@ -33,7 +32,6 @@ __lazy_modules__ = [
     "subprocess",
     "sysconfig",
     "textwrap",
-    "typing",
 ]
 
 import csv
@@ -45,14 +43,12 @@ import shlex
 import shutil
 import subprocess
 import sysconfig
-from collections.abc import Iterable, Iterator, MutableMapping
 from dataclasses import dataclass
 from os.path import relpath
 from pathlib import Path
 from pprint import pprint
 from runpy import run_path
 from textwrap import dedent
-from typing import Any
 
 from build import ProjectBuilder
 from build.env import IsolatedEnv
@@ -64,8 +60,6 @@ from cibuildwheel import errors, platforms  # pylint: disable=cyclic-import
 from cibuildwheel.architecture import Architecture, arch_synonym
 from cibuildwheel.frontend import get_build_frontend_extra_flags, parse_config_settings
 from cibuildwheel.logger import log
-from cibuildwheel.options import BuildOptions, Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
@@ -73,6 +67,14 @@ from cibuildwheel.util.helpers import prepare_command
 from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.util.python_build_standalone import create_python_build_standalone_environment
 from cibuildwheel.venv import constraint_flags, find_uv, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, MutableMapping
+    from typing import Any
+
+    from cibuildwheel.options import BuildOptions, Options
+    from cibuildwheel.selector import BuildSelector
 
 ANDROID_TRIPLET = {
     "arm64_v8a": "aarch64-linux-android",

--- a/cibuildwheel/platforms/ios.py
+++ b/cibuildwheel/platforms/ios.py
@@ -30,7 +30,7 @@ import subprocess
 import sys
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, assert_never
+from typing import assert_never
 
 from filelock import FileLock
 
@@ -45,6 +45,7 @@ from cibuildwheel.util.helpers import prepare_command, unwrap_preserving_paragra
 from cibuildwheel.util.packaging import find_compatible_wheel
 from cibuildwheel.venv import constraint_flags, virtualenv
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Sequence, Set
 

--- a/cibuildwheel/platforms/linux.py
+++ b/cibuildwheel/platforms/linux.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
-    "cibuildwheel.options",
-    "cibuildwheel.selector",
     "cibuildwheel.util",
     "cibuildwheel.util.file",
     "cibuildwheel.util.helpers",
     "cibuildwheel.util.packaging",
     "collections",
-    "collections.abc",
     "contextlib",
     "pathlib",
     "subprocess",
@@ -22,23 +21,25 @@ import subprocess
 import sys
 import textwrap
 from collections import OrderedDict
-from collections.abc import Iterable, Iterator, Sequence, Set
 from pathlib import Path, PurePath, PurePosixPath
-from typing import TYPE_CHECKING, assert_never
+from typing import assert_never
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
 from cibuildwheel.frontend import get_build_frontend_extra_flags
 from cibuildwheel.logger import log
 from cibuildwheel.oci_container import OCIContainer, OCIContainerEngineConfig, OCIPlatform
-from cibuildwheel.options import BuildOptions, Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.file import copy_test_sources
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Sequence, Set
+
+    from cibuildwheel.options import BuildOptions, Options
+    from cibuildwheel.selector import BuildSelector
     from cibuildwheel.typing import PathOrStr
 
 ARCHITECTURE_OCI_PLATFORM_MAP = {

--- a/cibuildwheel/platforms/macos.py
+++ b/cibuildwheel/platforms/macos.py
@@ -1,11 +1,9 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
-    "cibuildwheel.architecture",
     "cibuildwheel.ci",
-    "cibuildwheel.environment",
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
-    "cibuildwheel.options",
-    "cibuildwheel.selector",
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.file",
@@ -13,7 +11,6 @@ __lazy_modules__ = [
     "cibuildwheel.util.packaging",
     "cibuildwheel.venv",
     "collections",
-    "collections.abc",
     "filelock",
     "inspect",
     "os",
@@ -38,27 +35,32 @@ import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Set
 from pathlib import Path
-from typing import Literal, assert_never
+from typing import assert_never
 
 from filelock import FileLock
 from packaging.version import Version
 
 from cibuildwheel import errors
-from cibuildwheel.architecture import Architecture
 from cibuildwheel.ci import detect_ci_provider
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import BuildFrontendName, get_build_frontend_extra_flags
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import CIBW_CACHE_PATH, copy_test_sources, download, move_file
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+    from typing import Literal
+
+    from cibuildwheel.architecture import Architecture
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 
 @functools.cache

--- a/cibuildwheel/platforms/pyodide.py
+++ b/cibuildwheel/platforms/pyodide.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.architecture",
-    "cibuildwheel.environment",
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
-    "cibuildwheel.options",
-    "cibuildwheel.selector",
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.file",
@@ -13,7 +12,6 @@ __lazy_modules__ = [
     "cibuildwheel.util.python_build_standalone",
     "cibuildwheel.venv",
     "collections",
-    "collections.abc",
     "filelock",
     "json",
     "os",
@@ -33,7 +31,6 @@ import subprocess
 import sys
 import tomllib
 import typing
-from collections.abc import Set
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Final, TypedDict
@@ -42,11 +39,8 @@ from filelock import FileLock
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
-from cibuildwheel.environment import ParsedEnvironment
 from cibuildwheel.frontend import get_build_frontend_extra_flags
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -64,6 +58,14 @@ from cibuildwheel.util.python_build_standalone import (
     create_python_build_standalone_environment,
 )
 from cibuildwheel.venv import constraint_flags, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Set
+
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/cibuildwheel/platforms/windows.py
+++ b/cibuildwheel/platforms/windows.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.architecture",
-    "cibuildwheel.environment",
     "cibuildwheel.frontend",
     "cibuildwheel.logger",
-    "cibuildwheel.options",
-    "cibuildwheel.selector",
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.file",
@@ -12,7 +11,6 @@ __lazy_modules__ = [
     "cibuildwheel.util.packaging",
     "cibuildwheel.venv",
     "collections",
-    "collections.abc",
     "filelock",
     "json",
     "os",
@@ -31,7 +29,6 @@ import platform as platform_module
 import shutil
 import subprocess
 import textwrap
-from collections.abc import MutableMapping, Sequence, Set
 from functools import cache
 from pathlib import Path
 from typing import assert_never
@@ -40,11 +37,8 @@ from filelock import FileLock
 
 from cibuildwheel import errors
 from cibuildwheel.architecture import Architecture
-from cibuildwheel.environment import ParsedEnvironment
-from cibuildwheel.frontend import BuildFrontendName, get_build_frontend_extra_flags
+from cibuildwheel.frontend import get_build_frontend_extra_flags
 from cibuildwheel.logger import log
-from cibuildwheel.options import Options
-from cibuildwheel.selector import BuildSelector
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call, shell
 from cibuildwheel.util.file import (
@@ -57,6 +51,15 @@ from cibuildwheel.util.file import (
 from cibuildwheel.util.helpers import prepare_command, unwrap
 from cibuildwheel.util.packaging import find_compatible_wheel, get_pip_version
 from cibuildwheel.venv import constraint_flags, find_uv, virtualenv
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping, Sequence, Set
+
+    from cibuildwheel.environment import ParsedEnvironment
+    from cibuildwheel.frontend import BuildFrontendName
+    from cibuildwheel.options import Options
+    from cibuildwheel.selector import BuildSelector
 
 
 def get_nuget_args(

--- a/cibuildwheel/projectfiles.py
+++ b/cibuildwheel/projectfiles.py
@@ -1,12 +1,17 @@
-__lazy_modules__ = ["configparser", "contextlib", "dependency_groups", "pathlib", "typing"]
+from __future__ import annotations
+
+__lazy_modules__ = ["configparser", "contextlib", "dependency_groups"]
 
 import ast
 import configparser
 import contextlib
-from pathlib import Path
-from typing import Any
 
 import dependency_groups
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
 
 
 def get_parent(node: ast.AST | None, depth: int = 1) -> ast.AST | None:

--- a/cibuildwheel/resources/_cross_venv.py
+++ b/cibuildwheel/resources/_cross_venv.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 # This module is copied into the site-packages directory of an Android build environment, and
 # activated via a .pth file when we want the environment to simulate Android.
 
-__lazy_modules__ = ["os", "pathlib", "platform", "re", "sys", "sysconfig", "typing"]
+__lazy_modules__ = ["os", "pathlib", "platform", "re", "sys", "sysconfig"]
 
 import os
 import platform
@@ -9,7 +11,10 @@ import re
 import sys
 import sysconfig
 from pathlib import Path
-from typing import Any
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def initialize() -> None:

--- a/cibuildwheel/resources/testing_temp_dir_file.py
+++ b/cibuildwheel/resources/testing_temp_dir_file.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 # this file is copied to the testing cwd, to raise the below error message if
 # pytest/unittest is run from there.
 
-__lazy_modules__ = ["sys", "typing"]
+__lazy_modules__ = ["sys"]
 
 import sys
 import unittest
-from typing import NoReturn
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import NoReturn
 
 
 class TestStringMethods(unittest.TestCase):

--- a/cibuildwheel/schema.py
+++ b/cibuildwheel/schema.py
@@ -1,9 +1,14 @@
-__lazy_modules__ = ["cibuildwheel.util", "json", "typing"]
+from __future__ import annotations
+
+__lazy_modules__ = ["cibuildwheel.util", "json"]
 
 import json
-from typing import Any
 
 from cibuildwheel.util import resources
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def get_schema(tool_name: str = "cibuildwheel") -> dict[str, Any]:

--- a/cibuildwheel/selector.py
+++ b/cibuildwheel/selector.py
@@ -1,22 +1,26 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "bracex",
     "fnmatch",
     "itertools",
     "packaging",
-    "packaging.specifiers",
     "packaging.version",
-    "typing",
 ]
 
 import dataclasses
 import itertools
 from enum import StrEnum
 from fnmatch import fnmatch
-from typing import Any
 
 import bracex
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from typing import Any
+
+    from packaging.specifiers import SpecifierSet
 
 
 def selector_matches(patterns: str, string: str) -> bool:
@@ -47,11 +51,11 @@ class EnableGroup(StrEnum):
     PyodidePrerelease = "pyodide-prerelease"
 
     @classmethod
-    def all_groups(cls) -> frozenset["EnableGroup"]:
+    def all_groups(cls) -> frozenset[EnableGroup]:
         return frozenset(cls)
 
     @classmethod
-    def parse_option_value(cls, value: str) -> frozenset["EnableGroup"]:
+    def parse_option_value(cls, value: str) -> frozenset[EnableGroup]:
         """
         Parses a string of space-separated values into a set of EnableGroup
         members. The string may contain group names or "all".

--- a/cibuildwheel/util/cmd.py
+++ b/cibuildwheel/util/cmd.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.errors",
-    "cibuildwheel.typing",
     "collections",
-    "collections.abc",
     "os",
     "shlex",
     "shutil",
@@ -15,11 +15,16 @@ import shutil
 import subprocess
 import sys
 import typing
-from collections.abc import Iterator, Mapping
-from typing import Final, Literal
+from typing import Final
 
 from cibuildwheel.errors import FatalError
-from cibuildwheel.typing import PathOrStr
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+    from typing import Literal
+
+    from cibuildwheel.typing import PathOrStr
 
 _IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/cibuildwheel/util/file.py
+++ b/cibuildwheel/util/file.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "certifi",
     "cibuildwheel.errors",
     "collections",
-    "collections.abc",
     "shutil",
     "ssl",
     "tarfile",
@@ -19,7 +20,6 @@ import ssl
 import tarfile
 import time
 import urllib.request
-from collections.abc import Callable
 from pathlib import Path, PurePath
 from typing import Final
 from zipfile import ZipFile
@@ -28,6 +28,10 @@ import certifi
 from platformdirs import user_cache_path
 
 from cibuildwheel.errors import FatalError
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 DEFAULT_CIBW_CACHE_PATH: Final[Path] = user_cache_path(appname="cibuildwheel", appauthor="pypa")
 CIBW_CACHE_PATH: Final[Path] = Path(

--- a/cibuildwheel/util/helpers.py
+++ b/cibuildwheel/util/helpers.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
-    "cibuildwheel.typing",
     "collections",
-    "collections.abc",
     "itertools",
-    "os",
     "re",
     "shlex",
     "textwrap",
@@ -11,14 +10,17 @@ __lazy_modules__ = [
 
 import dataclasses
 import itertools
-import os
 import re
 import shlex
 import textwrap
 from collections import defaultdict
-from collections.abc import Sequence
 
-from cibuildwheel.typing import PathOrStr
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    import os
+    from collections.abc import Sequence
+
+    from cibuildwheel.typing import PathOrStr
 
 
 def format_safe(template: str, **kwargs: str | os.PathLike[str]) -> str:

--- a/cibuildwheel/util/packaging.py
+++ b/cibuildwheel/util/packaging.py
@@ -1,24 +1,29 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.helpers",
     "collections",
-    "collections.abc",
     "packaging",
     "packaging.utils",
     "shlex",
 ]
 
 import shlex
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePath
-from typing import Any, Literal, Self, TypeVar
+from typing import TypeVar
 
 from packaging.utils import parse_wheel_filename
 
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.helpers import parse_key_value_string, unwrap
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from typing import Any, Literal, Self
 
 
 @dataclass(kw_only=True)

--- a/cibuildwheel/util/python_build_standalone.py
+++ b/cibuildwheel/util/python_build_standalone.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.util.file",
     "cibuildwheel.util.resources",
     "filelock",
     "fnmatch",
     "json",
-    "pathlib",
     "platform",
 ]
 
@@ -13,12 +14,15 @@ import functools
 import json
 import platform
 import typing
-from pathlib import Path
 
 from filelock import FileLock
 
 from cibuildwheel.util.file import download, extract_tar
 from cibuildwheel.util.resources import PYTHON_BUILD_STANDALONE_RELEASES
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class PythonBuildStandaloneAsset(typing.TypedDict):

--- a/cibuildwheel/util/resources.py
+++ b/cibuildwheel/util/resources.py
@@ -1,11 +1,15 @@
-__lazy_modules__ = ["cibuildwheel.typing", "tomllib", "typing"]
+from __future__ import annotations
+
+__lazy_modules__ = ["tomllib", "typing"]
 
 import functools
 import tomllib
 from pathlib import Path
 from typing import Final
 
-from cibuildwheel.typing import PlatformName
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from cibuildwheel.typing import PlatformName
 
 PATH: Final[Path] = Path(__file__).parent.parent / "resources"
 INSTALL_CERTIFI_SCRIPT: Final[Path] = PATH / "install_certifi.py"

--- a/cibuildwheel/venv.py
+++ b/cibuildwheel/venv.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 __lazy_modules__ = [
     "cibuildwheel.util",
     "cibuildwheel.util.cmd",
     "cibuildwheel.util.file",
     "collections",
-    "collections.abc",
     "contextlib",
     "filelock",
     "os",
@@ -22,7 +23,6 @@ import os
 import shutil
 import sys
 import tomllib
-from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
 
@@ -33,6 +33,10 @@ from packaging.version import Version
 from cibuildwheel.util import resources
 from cibuildwheel.util.cmd import call
 from cibuildwheel.util.file import CIBW_CACHE_PATH, download
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 _IS_WIN: Final[bool] = sys.platform.startswith("win")
 

--- a/unit_test/get_platform_test.py
+++ b/unit_test/get_platform_test.py
@@ -2,7 +2,6 @@ import contextlib
 import sys
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 import setuptools._distutils.util
@@ -10,6 +9,8 @@ import setuptools._distutils.util
 from cibuildwheel.ci import CIProvider, detect_ci_provider
 from cibuildwheel.errors import FatalError
 from cibuildwheel.platforms.windows import PythonConfiguration, setup_setuptools_cross_compile
+
+TYPE_CHECKING = False
 
 # monkeypatching os.name is too flaky. E.g. It works on my machine, but fails in pipeline
 if not sys.platform.startswith("win") and not TYPE_CHECKING:

--- a/unit_test/options_test.py
+++ b/unit_test/options_test.py
@@ -1,10 +1,10 @@
+from __future__ import annotations
+
 import os
 import platform as platform_module
 import textwrap
 import unittest.mock
-from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal
 
 import pytest
 
@@ -21,6 +21,11 @@ from cibuildwheel.platforms import ALL_PLATFORM_MODULES, get_build_identifiers
 from cibuildwheel.selector import EnableGroup
 from cibuildwheel.util import resources
 from cibuildwheel.util.packaging import DependencyConstraints
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Literal
 
 PYPROJECT_1 = """
 [tool.cibuildwheel]

--- a/unit_test/options_toml_test.py
+++ b/unit_test/options_toml_test.py
@@ -1,5 +1,4 @@
 import shlex
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -13,6 +12,7 @@ from cibuildwheel.options import (
     _resolve_cascade,
 )
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from pathlib import Path
 


### PR DESCRIPTION
This builds on and updates https://github.com/pypa/cibuildwheel/pull/2797.

We can avoid a lot more imports by using `TYPE_CHECKING=False` instead of importing it from `typing`, and move lots of other `typing` imports under `if TYPE_CHECKING:`. Also `__future__ import annotations` lets us move many more under this guard.

This PR is 1.4x faster than https://github.com/pypa/cibuildwheel/pull/2797 and 4x faster than upstream `main`. Using Python 3.15.0a7 from official macOS installer.

```console
❯ hyperfine --warmup 10 \
     -n "upstream"   --prepare "git checkout upstream/main"           "python3.15 -m cibuildwheel --help" \
     -n "Henry's PR" --prepare "git checkout henryiii/chore/fasthelp" "python3.15 -m cibuildwheel --help" \
     -n "Hugo's PR"  --prepare "git checkout main"                    "python3.15 -m cibuildwheel --help"
Benchmark 1: upstream
  Time (mean ± σ):     178.9 ms ±   5.2 ms    [User: 155.4 ms, System: 21.7 ms]
  Range (min … max):   171.4 ms … 188.1 ms    16 runs

Benchmark 2: Henry's PR
  Time (mean ± σ):      61.7 ms ±   4.9 ms    [User: 50.4 ms, System: 9.7 ms]
  Range (min … max):    56.7 ms …  76.4 ms    33 runs

Benchmark 3: Hugo's PR
  Time (mean ± σ):      44.7 ms ±   1.7 ms    [User: 36.6 ms, System: 7.1 ms]
  Range (min … max):    42.5 ms …  53.8 ms    52 runs

Summary
  Hugo's PR ran
    1.38 ± 0.12 times faster than Henry's PR
    4.01 ± 0.19 times faster than upstream
```

## Summary by Sourcery

Defer type-related imports and enable postponed annotations across the codebase to reduce startup overhead and speed up the CLI.

Enhancements:
- Use `from __future__ import annotations` and guard most typing and collections.abc imports with a TYPE_CHECKING flag to avoid importing them at runtime.
- Trim lazy module dependency lists to exclude typing and collections.abc where no longer needed, reducing unnecessary import work during CLI startup.